### PR TITLE
[noSuperReactions.css] Fix reaction count color (interactive-default to text-subtle)

### DIFF
--- a/Other/noSuperReactions.css
+++ b/Other/noSuperReactions.css
@@ -1,6 +1,6 @@
 /* mask super Reactions */
 [class*="reaction"][class*="reactionMe"] {background-color: var(--message-reacted-background) !important; border-color: var(--blurple-50) !important;}
-[class*="reactionCount"] {color: var(--interactive-normal) !important;}
+[class*="reactionCount"] {color: var(--text-subtle) !important;}
 [class*="effectsWrapper"] {display: none;}
 [class^="burstGlow"], [class*="reaction_"], .full-motion [class*="reaction"][class*="shakeReaction"] {
     box-shadow: none !important; 


### PR DESCRIPTION
Hello! This merge changes the reactionCount color from `var(--interactive-default)` to `var(--text-subtle)` as is used by Discord by default for reaction counts.

| Before | After |
| --- | --- |
| <img width="405" height="159" alt="image" src="https://github.com/user-attachments/assets/7b49ca83-94c9-46ee-997b-3c4da7fe3bb8" /> | <img width="405" height="150" alt="image" src="https://github.com/user-attachments/assets/e3549632-2639-49ab-9f56-de9a0bcdb2a2" /> |